### PR TITLE
Use fixture paths instead import export paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The `akeneo-bootstrap` command is shipped with the composer package `netresearch
 | *_PATH | Set this with the asterisk replaced by the job name in upper case (e.g. CATEGORY_IMPORT_PATH) to change the file path for a particular job (overrides EXPORT_PATH or IMPORT_PATH for this job) | - |
 | WEB_USER | User name to be set as owner for directories that need to be writable by Akeneo from Web | www-data.www-data |
 | PARAMETER_* | Any parameter (e.g. from pim_parameters.yml) which is NOT one of the above (f.e. `PARAMETER_INSTALLER_DATA="/opt/acme/fixtures"` to [use another dataset](https://docs.akeneo.com/1.7/cookbook/setup_data/customize_dataset.html) | - |
+| USE_FIXTURE_PATHS |  Set this to use configured import and export paths from fixture files. All other configured ..._PATH will ignored. | - |
 
 The configuration via environment variables was chosen because the package is primarily targeted at installations in Docker containers. If you don't use such and don't want to clutter your environment variables with the above, you could put them into an [.env file](https://docs.docker.com/compose/env-file/) and run [akeneo-bootstrap](#akeneo-bootstrap) and composer commands like this:
 

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -97,14 +97,22 @@ class Bootstrap
         if (!$this->configurationGenerated) {
             $this->generateConfiguration();
         }
-        $this->run([
+
+        $runCommands = [
             new BootKernel($this->output),
             new WaitForDb($this->output),
             new EnsurePimInstallation($this->output),
             new SetExportImportPaths($this->output),
             new LinkStaticDirectories($this->output),
             new EnsureChownDirectories($this->output)
-        ]);
+        ];
+
+        if (getenv('USE_FIXTURE_PATHS')) {
+            // removed SetExportImportPaths command
+            unset($runCommands[3]);
+        }
+
+        $this->run($runCommands);
         $this->runFromPackages('boot');
     }
 }


### PR DESCRIPTION
There are different ways to configure job paths. You can set IMPORT_PATH, EXPORT_PATH and job specific ..._PATH as env variables. You can also use the jobs.yml file in FixtureBundle to configure your job paths. If you use the SetImportExportPaths() command you have to configure job paths in env variables, for other important job parameters you can use jobs.yml file in FixtureBundle. In the jobs.yml file you can also configure import and export paths, so you have two places to configure paths. 

These change ignores the SetImportExportPaths() command using USE_FIXTURE_PATHS env variable.